### PR TITLE
App-keyboard: support pm in ppt mode

### DIFF
--- a/app/include/zmk/board.h
+++ b/app/include/zmk/board.h
@@ -8,6 +8,7 @@
 
 #include <stdint.h>
 
-#define DLPS_EN             0
+#define ENABLE_2_4G_LOG     0
 
-#define ENABLE_2_4G_LOG     1
+#define PPT_PAIR_RSSI       -65
+#define FEATURE_SUPPORT_PROPRIETARY_TRANSPORT   0

--- a/app/include/zmk/ppt/keyboard_ppt_app.h
+++ b/app/include/zmk/ppt/keyboard_ppt_app.h
@@ -88,6 +88,7 @@ void keyboard_ppt_enable(void);
 void keyboard_ppt_pair(void);
 void keyboard_ppt_reconnect(void);
 void keyboard_ppt_stop_sync(void);
+void keyboard_ppt_set_sync_interval(void);
 bool keyboard_app_ppt_send_data(sync_msg_type_t type, uint8_t msg_retrans_count,
                                 T_KEYBOARD_DATA keyboard_data);
 enum zmk_ppt_conn_state zmk_ppt_get_conn_state(void);

--- a/app/src/ppt.c
+++ b/app/src/ppt.c
@@ -28,18 +28,19 @@ static uint8_t *get_keyboard_report(size_t *len) {
 }
 
 static int zmk_ppt_send_report(uint8_t *report, size_t len) {
-    for(uint8_t i=0; i<len; i++)
-    {
-        DBG_DIRECT("ppt send data:0x%x", report[i]);
-    }
-    ppt_app_send_data(SYNC_MSG_TYPE_DYNAMIC_RETRANS,0,report,len);
+    // for(uint8_t i=0; i<len; i++)
+    // {
+    //     DBG_DIRECT("ppt send data:0x%x", report[i]);
+    // }
+    int err = ppt_app_send_data(SYNC_MSG_TYPE_DYNAMIC_RETRANS,0,report,len);
+    return err;
 }
 
 int zmk_ppt_send_keyboard_report(void) {
     size_t len;
     uint8_t *report = get_keyboard_report(&len);
     DBG_DIRECT("zmk ppt send keyboard data, len is %d",len);
-    
+
     uint8_t opcode = SYNC_OPCODE_KEYBOARD;
     uint8_t ppt_report[len+1];
     ppt_report[0] = opcode;
@@ -48,9 +49,9 @@ int zmk_ppt_send_keyboard_report(void) {
 }
 
 int zmk_ppt_send_consumer_report(void) {
-    DBG_DIRECT("zmk ppt send consumer data");
     struct zmk_hid_consumer_report *report = zmk_hid_get_consumer_report();
     uint16_t len = sizeof(*report);
+    DBG_DIRECT("zmk ppt send consumer data, len is %d",len);
 
     uint8_t opcode = SYNC_OPCODE_CONSUMER;
     uint8_t ppt_report[len+1];

--- a/app/src/ppt/keyboard_ppt_app.c
+++ b/app/src/ppt/keyboard_ppt_app.c
@@ -20,9 +20,10 @@
 
 LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
 
+#if FEATURE_SUPPORT_NO_ACTION_DISCONN
 static void no_act_disconn_timer_callback(struct k_timer *p_timer);
 static K_TIMER_DEFINE(no_act_disconn_timer, no_act_disconn_timer_callback, NULL);
-
+#endif
 /*============================================================================*
  *                             Macro
  *============================================================================*/
@@ -231,6 +232,19 @@ void keyboard_ppt_stop_sync(void)
 }
 
 /******************************************************************
+ * @brief  keyboard_ppt_set_sync_interval
+ * @param  none
+ * @return none
+ * @retval void
+ */
+void keyboard_ppt_set_sync_interval(void)
+{
+    uint32_t ppt_interval_time_us = PPT_REPORT_RATE_LEVEL_0;
+    sync_time_set(SYNC_TIME_PARAM_CONNECT_INTERVAL, ppt_interval_time_us);
+    sync_time_set(SYNC_TIME_PARAM_CONNECT_INTERVAL_HIGH, ppt_interval_time_us);
+}
+
+/******************************************************************
  * @brief  keyboard_ppt_init
  * @param  none
  * @return none
@@ -245,10 +259,11 @@ void keyboard_ppt_init(void)
     ppt_app_global_data.keyboard_ppt_status = KEYBOARD_PPT_STATUS_IDLE;
     ppt_app_global_data.is_ppt_bond = ppt_check_is_bonded();
     DBG_DIRECT("ppt_app_global_data.is_ppt_bond = %d", ppt_app_global_data.is_ppt_bond);
-    uint32_t ppt_interval_time_us = PPT_REPORT_RATE_LEVEL_0 ;
+
+    sync_pair_rssi_set(PPT_PAIR_RSSI);
+
     /* set 2.4g connection interval */
-    sync_time_set(SYNC_TIME_PARAM_CONNECT_INTERVAL, ppt_interval_time_us);
-    DBG_DIRECT("ppt_interval_time_us = %d us", ppt_interval_time_us);
+    keyboard_ppt_set_sync_interval();
 
     /* set 2.4g connection heart beat interval */
     sync_master_set_hb_param(2, PPT_DEFAULT_HEARTBEAT_INTERVAL_TIME, 0);
@@ -263,8 +278,9 @@ void keyboard_ppt_init(void)
 
 #if !ENABLE_2_4G_LOG
     sync_log_set(0, false);
+#else
+    sync_log_set(0, true);
 #endif
-    sync_log_set(0,true);
 }
 
 /******************************************************************


### PR DESCRIPTION
1. register enhance timer pm function
2. enable ppt sync init when enable CONFIG_PM_DEVICE

<!-- If you're adding a board/shield please fill out this check-list, otherwise you can delete it -->

## Board/Shield Check-list

- [ ] This board/shield is tested working on real hardware
- [ ] Definitions follow the general style of other shields/boards upstream ([Reference](https://zmk.dev/docs/development/new-shield))
- [ ] `.zmk.yml` metadata file added
- [ ] Proper Copyright + License headers added to applicable files (Generally, we stick to "The ZMK Contributors" for copyrights to help avoid churn when files get edited)
- [ ] General consistent formatting of DeviceTree files
- [ ] Keymaps do not use deprecated key defines (Check using the [upgrader tool](https://zmk.dev/docs/codes/keymap-upgrader))
- [ ] `&pro_micro` used in favor of `&pro_micro_d/a` if applicable
- [ ] If split, no name added for the right/peripheral half
- [ ] Kconfig.defconfig file correctly wraps _all_ configuration in conditional on the shield symbol
- [ ] `.conf` file has optional extra features commented out
- [ ] Keyboard/PCB is part of a shipped group buy or is generally available in stock to purchase (OSH/personal projects without general availability should create a zmk-config repo instead)
